### PR TITLE
chore(design-tokens): added support for negative dimension tokens

### DIFF
--- a/.changeset/witty-icons-rule.md
+++ b/.changeset/witty-icons-rule.md
@@ -1,0 +1,5 @@
+---
+"@juxio/design-tokens": patch
+---
+
+chore(design-tokens): added support for negative dimension tokens

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npx pnpm lint-staged

--- a/packages/design-tokens/src/constants.ts
+++ b/packages/design-tokens/src/constants.ts
@@ -28,6 +28,10 @@ export const DIMENSION_TOKEN_VALUE_UNITS = [
 ] as const;
 
 export const DIMENSION_TOKEN_VALUE_REGEX = new RegExp(
+  `^-?(\\d*(\\.\\d+)?(${DIMENSION_TOKEN_VALUE_UNITS.join('|')}))?$`
+);
+
+export const DIMENSION_TOKEN_VALUE_REGEX_POSITIVE_ONLY = new RegExp(
   `^(\\d*(\\.\\d+)?(${DIMENSION_TOKEN_VALUE_UNITS.join('|')}))?$`
 );
 
@@ -36,6 +40,8 @@ export const DIMENSION_DEFINITION_MESSAGE = `number followed by a unit (${DIMENS
 )})`;
 
 export const DIMENSION_TOKEN_VALUE_REGEX_MESSAGE = `Enter a ${DIMENSION_DEFINITION_MESSAGE}`;
+
+export const DIMENSION_TOKEN_VALUE_REGEX_POSITIVE_ONLY_MESSAGE = `Enter a positive ${DIMENSION_DEFINITION_MESSAGE}`;
 
 export const NUMBER_TOKEN_VALUE_REGEX = /^\d*(\.\d+)?$/;
 

--- a/packages/design-tokens/src/schemas/tokenset.schema.ts
+++ b/packages/design-tokens/src/schemas/tokenset.schema.ts
@@ -9,6 +9,8 @@ import {
   COLOR_TOKEN_VALUE_REGEX_MESSAGE,
   STROKE_STYLE_TOKEN_VALUE_REGEX,
   STROKE_STYLE_TOKEN_VALUE_REGEX_MESSAGE,
+  DIMENSION_TOKEN_VALUE_REGEX_POSITIVE_ONLY,
+  DIMENSION_TOKEN_VALUE_REGEX_POSITIVE_ONLY_MESSAGE,
 } from '../constants';
 
 /* Token values */
@@ -26,6 +28,13 @@ export const strokeStyleTokenValueSchema = z
 export const dimensionTokenValueSchema = z
   .string()
   .regex(DIMENSION_TOKEN_VALUE_REGEX, DIMENSION_TOKEN_VALUE_REGEX_MESSAGE);
+
+export const dimensionTokenValueSchemaPositiveOnly = z
+  .string()
+  .regex(
+    DIMENSION_TOKEN_VALUE_REGEX_POSITIVE_ONLY,
+    DIMENSION_TOKEN_VALUE_REGEX_POSITIVE_ONLY_MESSAGE
+  );
 
 export const fontFamilyTokenValueSchema = z.string();
 
@@ -73,7 +82,7 @@ export const typographyTokenSchema = z.object({
 
 export const borderTokenValueSchema = z.object({
   color: aliasTokenValueSchema.or(colorTokenValueSchema),
-  width: aliasTokenValueSchema.or(dimensionTokenValueSchema),
+  width: aliasTokenValueSchema.or(dimensionTokenValueSchemaPositiveOnly),
   style: strokeStyleTokenValueSchema,
 });
 


### PR DESCRIPTION
### Description
Updated dimension token schemas to support negative values

### Screenshots
<img width="509" alt="image" src="https://github.com/user-attachments/assets/f5205203-fe4f-47ce-86c9-e795bdb01660" />
